### PR TITLE
chore: add missing shared CI workflows

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -1,15 +1,14 @@
-name: Run UnitTests
+name: Build Tests
+
 on:
-  push:
   pull_request:
-    branches:
-      - dev
+    branches: [dev, master, main]
   workflow_dispatch:
 
 jobs:
-  build_tests:
+  build:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     secrets: inherit
     with:
-      install_extras: "test"
-      test_path: "test"
+      install_extras: 'test'
+      test_path: 'test'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,17 @@
+name: Code Coverage
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/coverage.yml@dev
+    secrets: inherit
+    with:
+      python_version: '3.11'
+      coverage_source: 'ovos_chromadb_embeddings'
+      test_path: 'test'
+      install_extras: '.[test]'
+      min_coverage: 0

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -1,0 +1,11 @@
+name: License Check
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  license_check:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
+    secrets: inherit

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -9,3 +9,5 @@ jobs:
   license_check:
     uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
     secrets: inherit
+    with:
+      exclude_packages: "(?i:^tqdm(:.*)?$)|(?i:^orjson(:.*)?$)"

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -10,4 +10,4 @@ jobs:
     uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
     secrets: inherit
     with:
-      exclude_packages: "(?i:^tqdm(:.*)?$)|(?i:^orjson(:.*)?$)"
+      exclude_packages: '(?i:^tqdm([=<>!~ @;].*)?$)|(?i:^orjson([=<>!~ @;].*)?$)'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [dev, master, main]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/lint.yml@dev
+    secrets: inherit
+    with:
+      ruff: true
+      pre_commit: false

--- a/.github/workflows/opm-check.yml
+++ b/.github/workflows/opm-check.yml
@@ -1,0 +1,14 @@
+name: OPM Plugin Check
+
+on:
+  pull_request:
+    branches: [dev, master, main]
+  workflow_dispatch:
+
+jobs:
+  opm_check:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/opm-check.yml@dev
+    secrets: inherit
+    with:
+      python_version: '3.11'
+      plugin_type: 'auto'

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -1,0 +1,11 @@
+name: PIP Audit
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  pip_audit:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/pip-audit.yml@dev
+    secrets: inherit

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,14 @@
+name: Release Preview
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  release_preview:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/release-preview.yml@dev
+    secrets: inherit
+    with:
+      package_name: 'ovos_chromadb_embeddings'
+      version_file: 'ovos_chromadb_embeddings/version.py'

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -1,0 +1,13 @@
+name: Repo Health
+
+on:
+  pull_request:
+    branches: [dev, master, main]
+  workflow_dispatch:
+
+jobs:
+  repo_health:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/repo-health.yml@dev
+    secrets: inherit
+    with:
+      version_file: 'ovos_chromadb_embeddings/version.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{name = "jarbasai", email = "jarbasai@mailfence.com"}]
 requires-python = ">=3.9"
 keywords = ["OVOS", "openvoiceos", "plugin", "chromadb", "embeddings"]
 dependencies = [
-    "ovos-plugin-manager>=2.0.0a1",
+    "ovos-plugin-manager>=2.1.0,<3.0.0",
     "numpy",
     "chromadb",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{name = "jarbasai", email = "jarbasai@mailfence.com"}]
 requires-python = ">=3.9"
 keywords = ["OVOS", "openvoiceos", "plugin", "chromadb", "embeddings"]
 dependencies = [
-    "ovos-plugin-manager>=0.1.0,<3.0.0",
+    "ovos-plugin-manager>=2.0.0a1",
     "numpy",
     "chromadb",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-ovos-plugin-manager>=2.0.0a1
-numpy
-chromadb


### PR DESCRIPTION
Roll out canonical OpenVoiceOS/gh-automations reusable-workflow callers (`@dev`, `secrets: inherit`).

Added: coverage (pkg `ovos_chromadb_embeddings`, tests `test/`, extras `.[test]`), lint, license-check, pip-audit, repo-health, release-preview, opm-check.
Already present (OpenVoiceOS@dev): build-tests, publish-alpha, publish-stable, conventional-label.