### PR TITLE
docs: explain where the store fits in OVOS + query distance semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,28 @@ This plugin registers as:
 opm.embeddings → ovos-chromadb-embeddings-plugin → ChromaEmbeddingsDB
 ```
 
-OVOS subsystems (e.g. memory, RAG pipelines, face/voice recognition) call
-`OVOSPluginFactory.get_plugin("opm.embeddings")` to obtain a configured store without
-coupling to a specific backend.
+OVOS subsystems call `OVOSPluginFactory.get_plugin("opm.embeddings")` to obtain a
+configured store without coupling to a specific backend, so any `EmbeddingsDB` plugin
+(ChromaDB here, or e.g. [qdrant](https://github.com/OpenVoiceOS/ovos-qdrant-embeddings-plugin))
+is a drop-in swap.
+
+## Where this fits in OVOS
+
+This plugin is the **vector store** half of the stack — it stores and searches vectors but
+does not produce them. Pair it with an embedding producer such as
+[ovos-gguf-embeddings-plugin](https://github.com/OpenVoiceOS/ovos-gguf-embeddings-plugin)
+(text → vectors), or the [face](https://github.com/OpenVoiceOS/ovos-face-embeddings-plugin)
+/ [voice](https://github.com/OpenVoiceOS/ovos-voice-embeddings-plugin) embedders.
+
+Concrete consumers that can be backed by this store:
+
+| Consumer | Uses the store for |
+|---|---|
+| [ovos-persona-server](https://github.com/OpenVoiceOS/ovos-persona-server) | RAG: the OpenAI-compatible Files / Vector-Stores / `/search` endpoints |
+| [ovos-memory-plugins](https://github.com/OpenVoiceOS/ovos-memory-plugins) | long-term semantic memory for a persona |
+| face / voice recognition | nearest-neighbour identity lookup over enrolment vectors |
+
+It is local-first: in persistent mode it runs fully offline on a CPU with no server.
 
 ## Quickstart
 
@@ -45,9 +64,10 @@ with tempfile.TemporaryDirectory() as tmp:
     print(results[0][0])  # "apple"
 ```
 
-Pair with an embedding producer such as
-[ovos-gguf-embeddings-plugin](https://github.com/OpenVoiceOS/ovos-gguf-embeddings-plugin)
-(`ovos-gguf-plugin`) to convert text → vectors before storing them here.
+`query` returns `(id, distance)` tuples ordered nearest-first. The score is a **distance**,
+not a similarity — **lower is closer** for the default `cosine` metric (and for `l2`). Change
+the metric with `hnsw:space` (see [Configuration](#configuration)). The query vector must have
+the same dimensionality as the stored vectors.
 
 ## Configuration
 


### PR DESCRIPTION
Substantive README improvements:

- **New "Where this fits in OVOS" section** — clarifies this plugin is the *vector-store* half (stores/searches vectors, does not produce them) and pairs with an embedding producer (gguf/face/voice). Adds a table of concrete consumers: persona-server RAG (Files/Vector-Stores/`/search`), ovos-memory long-term memory, and face/voice recognition. Notes it runs fully offline/local-first in persistent mode.
- Clarifies `EmbeddingsDB` backends are drop-in swappable (chromadb ↔ qdrant).
- **Documents `query` return semantics** — `(id, distance)` tuples, distance (not similarity), lower-is-closer for cosine/l2; query/stored dimensionality must match.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced "Where this fits in OVOS" section with clearer plugin description and added table of consumer projects
  * Clarified `query` method documentation to specify results as (id, distance) tuples with improved explanations of distance metrics and vector dimensionality requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->